### PR TITLE
Added two new filters for async and defer

### DIFF
--- a/net/instaweb/instaweb.gyp
+++ b/net/instaweb/instaweb.gyp
@@ -1816,6 +1816,8 @@
         'rewriter/resource_tag_scanner.cc',
         'rewriter/rewrite_context.cc',
         'rewriter/rewrite_driver.cc',
+        'rewriter/webscale_make_scripts_async.cc',
+        'rewriter/webscale_make_scripts_defer.cc',  
         'rewriter/rewrite_driver_factory.cc',
         'rewriter/rewrite_driver_pool.cc',
         'rewriter/rewrite_filter.cc',

--- a/net/instaweb/rewriter/public/rewrite_options.h
+++ b/net/instaweb/rewriter/public/rewrite_options.h
@@ -197,6 +197,8 @@ class RewriteOptions {
     kStripImageMetaData,
     kStripNonCacheable,
     kStripScripts,
+    kWebscaleMakeScriptsAsync,
+    kWebscaleMakeScriptsDefer,
     kEndOfFilters
   };
 
@@ -435,6 +437,8 @@ class RewriteOptions {
   static const char kCacheFlushFilename[];
   static const char kCacheFlushPollIntervalSec[];
   static const char kCompressMetadataCache[];
+  static const char kCustomAsyncUrl[];
+  static const char kCustomDeferUrl[];
   static const char kFetcherProxy[];
   static const char kFetchFromModSpdy[];
   static const char kFetchHttps[];
@@ -1151,6 +1155,26 @@ class RewriteOptions {
 
   int num_custom_fetch_headers() const {
     return custom_fetch_headers_.size();
+  }
+
+  void AddCustomAsyncUrl(const StringPiece& name);
+
+  const GoogleString* custom_async_url(int i) const {
+    return (new GoogleString(custom_async_urls_[i]->data(), custom_async_urls_[i]->size()));
+  }
+
+  int num_custom_async_urls() const {
+    return custom_async_urls_.size();
+  }
+
+  void AddCustomDeferUrl(const StringPiece& name);
+
+  const GoogleString* custom_defer_url(int i) const {
+    return (new GoogleString(custom_defer_urls_[i]->data(), custom_defer_urls_[i]->size()));
+  }
+
+  int num_custom_defer_urls() const {
+    return custom_defer_urls_.size();
   }
 
   // Returns the spec with the id_ that matches id.  Returns NULL if no
@@ -4333,6 +4357,9 @@ class RewriteOptions {
 
   // Headers to add to subresource requests.
   std::vector<NameValue*> custom_fetch_headers_;
+
+  std::vector<GoogleString*> custom_async_urls_;
+  std::vector<GoogleString*> custom_defer_urls_;
 
   // If this is non-NULL it tells us additional attributes that should be
   // interpreted as containing urls.

--- a/net/instaweb/rewriter/public/webscale_make_scripts_async.h
+++ b/net/instaweb/rewriter/public/webscale_make_scripts_async.h
@@ -27,13 +27,13 @@ class WebscaleMakeScriptsAsync : public CommonFilter {
   explicit WebscaleMakeScriptsAsync(RewriteDriver* rewrite_driver);
   virtual ~WebscaleMakeScriptsAsync();
 
-  // statistics is not really used. The comments in
+  // Statistics is not really used. The comments in
   // net/instaweb/rewriter/rewrite_driver.cc mentions that it is good for all
-  // new filters to export statistics. If it does, it should be added
-  // InitStats() else it breaks under Apache.
+  // new filters to export statistics. If it does, it should be added to
+  // InitStats(), else it breaks under Apache.
   static void InitStats(Statistics* statistics);
 
-  // Constructs a string with all custom urls escaped and or-red.
+  // Constructs a string with all custom urls escaped and separated by bitwise OR operators.
   // Returns a string that is stored in escaped_urls.
   static GoogleString ConstructPatternFromCustomUrls(const RewriteOptions* options);
 
@@ -49,7 +49,7 @@ class WebscaleMakeScriptsAsync : public CommonFilter {
   }
 
   private:
-    // A string which contains the custom urls escaped and or-red.
+    // A string which contains the custom urls escaped and separated by bitwise OR operators.
     // Example: If the custom urls are ["js/a1.js", "js/a2.js"]
     // escaped_urls will finally be: "js\/a1\\.js|js\\/a2\\.js"
     GoogleString escaped_urls;

--- a/net/instaweb/rewriter/public/webscale_make_scripts_async.h
+++ b/net/instaweb/rewriter/public/webscale_make_scripts_async.h
@@ -1,0 +1,51 @@
+/*
+ *  COPYRIGHT:
+ *     (C) Copyright Webscale Networks 2017.
+ *     Licensed Materials - All Rights Reserved.
+ *
+*/
+
+#ifndef NET_INSTAWEB_REWRITER_PUBLIC_WEBSCALE_MAKE_SCRIPTS_ASYNC_H_
+#define NET_INSTAWEB_REWRITER_PUBLIC_WEBSCALE_MAKE_SCRIPTS_ASYNC_H_
+
+#include<vector>
+
+#include "net/instaweb/rewriter/public/common_filter.h"
+#include "pagespeed/kernel/base/basictypes.h"
+#include "pagespeed/kernel/base/string.h"
+
+namespace net_instaweb {
+
+class HtmlCharactersNode;
+class HtmlElement;
+class MessageHandler;
+class RewriteDriver;
+
+class WebscaleMakeScriptsAsync : public CommonFilter {
+ public:
+  explicit WebscaleMakeScriptsAsync(RewriteDriver* rewrite_driver, MessageHandler* handler);
+  virtual ~WebscaleMakeScriptsAsync();
+
+  static void InitStats(Statistics* statistics);
+
+  static GoogleString ConstructPatternFromCustomUrls(const RewriteOptions* options);
+
+  // Overrides CommonFilter
+  virtual void StartDocumentImpl();
+  virtual void StartElementImpl(HtmlElement* element);
+  virtual void EndElementImpl(HtmlElement* element);
+  virtual void EndDocument();
+
+  // Overrides HtmlFilter
+  virtual const char* Name() const {
+    return "WebscaleMakeScriptsAsync";
+  }
+
+  MessageHandler* message_handler;
+  GoogleString escaped_urls;
+
+  DISALLOW_COPY_AND_ASSIGN(WebscaleMakeScriptsAsync);
+};
+} // namespace net_instaweb
+
+#endif // NET_INSTAWEB_REWRITER_PUBLIC_WEBSCALE_MAKE_SCRIPTS_ASYNC_H_

--- a/net/instaweb/rewriter/public/webscale_make_scripts_async.h
+++ b/net/instaweb/rewriter/public/webscale_make_scripts_async.h
@@ -21,13 +21,20 @@ class HtmlElement;
 class MessageHandler;
 class RewriteDriver;
 
+// Filter to async custom third-party scripts.
 class WebscaleMakeScriptsAsync : public CommonFilter {
  public:
-  explicit WebscaleMakeScriptsAsync(RewriteDriver* rewrite_driver, MessageHandler* handler);
+  explicit WebscaleMakeScriptsAsync(RewriteDriver* rewrite_driver);
   virtual ~WebscaleMakeScriptsAsync();
 
+  // statistics is not really used. The comments in
+  // net/instaweb/rewriter/rewrite_driver.cc mentions that it is good for all
+  // new filters to export statistics. If it does, it should be added
+  // InitStats() else it breaks under Apache.
   static void InitStats(Statistics* statistics);
 
+  // Constructs a string with all custom urls escaped and or-red.
+  // Returns a string that is stored in escaped_urls.
   static GoogleString ConstructPatternFromCustomUrls(const RewriteOptions* options);
 
   // Overrides CommonFilter
@@ -41,8 +48,11 @@ class WebscaleMakeScriptsAsync : public CommonFilter {
     return "WebscaleMakeScriptsAsync";
   }
 
-  MessageHandler* message_handler;
-  GoogleString escaped_urls;
+  private:
+    // A string which contains the custom urls escaped and or-red.
+    // Example: If the custom urls are ["js/a1.js", "js/a2.js"]
+    // escaped_urls will finally be: "js\/a1\\.js|js\\/a2\\.js"
+    GoogleString escaped_urls;
 
   DISALLOW_COPY_AND_ASSIGN(WebscaleMakeScriptsAsync);
 };

--- a/net/instaweb/rewriter/public/webscale_make_scripts_defer.h
+++ b/net/instaweb/rewriter/public/webscale_make_scripts_defer.h
@@ -1,0 +1,51 @@
+/*
+ *  COPYRIGHT:
+ *      (C) Copyright Webscale Networks 2017.
+ *       Licensed Materials - All Rights Reserved.
+ *
+*/
+
+#ifndef NET_INSTAWEB_REWRITER_PUBLIC_WEBSCALE_MAKE_SCRIPTS_DEFER_H_
+#define NET_INSTAWEB_REWRITER_PUBLIC_WEBSCALE_MAKE_SCRIPTS_DEFER_H_
+
+#include<vector>
+
+#include "net/instaweb/rewriter/public/common_filter.h"
+#include "pagespeed/kernel/base/basictypes.h"
+#include "pagespeed/kernel/base/string.h"
+
+namespace net_instaweb {
+
+class HtmlCharactersNode;
+class HtmlElement;
+class MessageHandler;
+class RewriteDriver;
+
+class WebscaleMakeScriptsDefer : public CommonFilter {
+ public:
+  explicit WebscaleMakeScriptsDefer(RewriteDriver* rewrite_driver, MessageHandler* handler);
+  virtual ~WebscaleMakeScriptsDefer();
+
+  static void InitStats(Statistics* statistics);
+
+  static GoogleString ConstructPatternFromCustomUrls(const RewriteOptions* options);
+
+  // Overrides CommonFilter
+  virtual void StartDocumentImpl();
+  virtual void StartElementImpl(HtmlElement* element);
+  virtual void EndElementImpl(HtmlElement* element);
+  virtual void EndDocument();
+
+  // Overrides HtmlFilter
+  virtual const char* Name() const {
+    return "WebscaleMakeScriptsDefer";
+  }
+
+  MessageHandler* message_handler;
+  GoogleString escaped_urls;
+
+  DISALLOW_COPY_AND_ASSIGN(WebscaleMakeScriptsDefer);
+};
+} // namespace net_instaweb
+
+#endif // NET_INSTAWEB_REWRITER_PUBLIC_WEBSCALE_MAKE_SCRIPTS_DEFER_H_

--- a/net/instaweb/rewriter/public/webscale_make_scripts_defer.h
+++ b/net/instaweb/rewriter/public/webscale_make_scripts_defer.h
@@ -27,13 +27,13 @@ class WebscaleMakeScriptsDefer : public CommonFilter {
   explicit WebscaleMakeScriptsDefer(RewriteDriver* rewrite_driver);
   virtual ~WebscaleMakeScriptsDefer();
 
-  // statistics is not really used. The comments in
+  // Statistics is not really used. The comments in
   // net/instaweb/rewriter/rewrite_driver.cc mentions that it is good for all
-  // new filters to export statistics. If it does, it should be added
+  // new filters to export statistics. If it does, it should be added to
   // InitStats() else it breaks under Apache.
   static void InitStats(Statistics* statistics);
 
-  // Constructs a string with all custom urls escaped and or-red.
+  // Constructs a string with all custom urls escaped and separated by bitwise OR operators.
   // Returns a string that is stored in escaped_urls.
   static GoogleString ConstructPatternFromCustomUrls(const RewriteOptions* options);
 
@@ -49,7 +49,7 @@ class WebscaleMakeScriptsDefer : public CommonFilter {
   }
 
   private:
-    // A string which contains the custom urls escaped and or-red.
+    // A string which contains the custom urls escaped separated by bitwise OR operators.
     // Example: If the custom urls are ["js/a1.js", "js/a2.js"]
     // escaped_urls will finally be: "js\/a1\\.js|js\\/a2\\.js"
     GoogleString escaped_urls;

--- a/net/instaweb/rewriter/public/webscale_make_scripts_defer.h
+++ b/net/instaweb/rewriter/public/webscale_make_scripts_defer.h
@@ -21,13 +21,20 @@ class HtmlElement;
 class MessageHandler;
 class RewriteDriver;
 
+// Filter to defer custom third-party scripts.
 class WebscaleMakeScriptsDefer : public CommonFilter {
  public:
-  explicit WebscaleMakeScriptsDefer(RewriteDriver* rewrite_driver, MessageHandler* handler);
+  explicit WebscaleMakeScriptsDefer(RewriteDriver* rewrite_driver);
   virtual ~WebscaleMakeScriptsDefer();
 
+  // statistics is not really used. The comments in
+  // net/instaweb/rewriter/rewrite_driver.cc mentions that it is good for all
+  // new filters to export statistics. If it does, it should be added
+  // InitStats() else it breaks under Apache.
   static void InitStats(Statistics* statistics);
 
+  // Constructs a string with all custom urls escaped and or-red.
+  // Returns a string that is stored in escaped_urls.
   static GoogleString ConstructPatternFromCustomUrls(const RewriteOptions* options);
 
   // Overrides CommonFilter
@@ -41,8 +48,11 @@ class WebscaleMakeScriptsDefer : public CommonFilter {
     return "WebscaleMakeScriptsDefer";
   }
 
-  MessageHandler* message_handler;
-  GoogleString escaped_urls;
+  private:
+    // A string which contains the custom urls escaped and or-red.
+    // Example: If the custom urls are ["js/a1.js", "js/a2.js"]
+    // escaped_urls will finally be: "js\/a1\\.js|js\\/a2\\.js"
+    GoogleString escaped_urls;
 
   DISALLOW_COPY_AND_ASSIGN(WebscaleMakeScriptsDefer);
 };

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -1094,12 +1094,10 @@ void RewriteDriver::AddPreRenderFilters() {
     AppendOwnedPreRenderFilter(new MakeShowAdsAsyncFilter(this));
   }
   if (rewrite_options->Enabled(RewriteOptions::kWebscaleMakeScriptsAsync)) {
-    MessageHandler* handler = message_handler();
-    AppendOwnedPreRenderFilter(new WebscaleMakeScriptsAsync(this, handler));
+    AppendOwnedPreRenderFilter(new WebscaleMakeScriptsAsync(this));
   }
   if (rewrite_options->Enabled(RewriteOptions::kWebscaleMakeScriptsDefer)) {
-    MessageHandler* handler = message_handler();
-    AppendOwnedPreRenderFilter(new WebscaleMakeScriptsDefer(this, handler));
+    AppendOwnedPreRenderFilter(new WebscaleMakeScriptsDefer(this));
   }
   if (rewrite_options->Enabled(RewriteOptions::kSplitHtml) &&
       server_context()->factory()->UseBeaconResultsInFilters()) {

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -133,6 +133,8 @@
 #include "net/instaweb/rewriter/public/url_input_resource.h"
 #include "net/instaweb/rewriter/public/url_left_trim_filter.h"
 #include "net/instaweb/rewriter/public/url_namer.h"
+#include "net/instaweb/rewriter/public/webscale_make_scripts_async.h"
+#include "net/instaweb/rewriter/public/webscale_make_scripts_defer.h"
 #include "net/instaweb/util/public/fallback_property_page.h"
 #include "pagespeed/kernel/base/basictypes.h"
 #include "pagespeed/kernel/base/callback.h"
@@ -905,6 +907,8 @@ void RewriteDriver::InitStats(Statistics* statistics) {
   RewriteContext::InitStats(statistics);
   UrlInputResource::InitStats(statistics);
   UrlLeftTrimFilter::InitStats(statistics);
+  WebscaleMakeScriptsAsync::InitStats(statistics);
+  WebscaleMakeScriptsDefer::InitStats(statistics);
 }
 
 void RewriteDriver::Terminate() {
@@ -1088,6 +1092,14 @@ void RewriteDriver::AddPreRenderFilters() {
   if (rewrite_options->Enabled(RewriteOptions::kMakeShowAdsAsync)) {
     // We want this filter early in case we ever inline the loader JS.
     AppendOwnedPreRenderFilter(new MakeShowAdsAsyncFilter(this));
+  }
+  if (rewrite_options->Enabled(RewriteOptions::kWebscaleMakeScriptsAsync)) {
+    MessageHandler* handler = message_handler();
+    AppendOwnedPreRenderFilter(new WebscaleMakeScriptsAsync(this, handler));
+  }
+  if (rewrite_options->Enabled(RewriteOptions::kWebscaleMakeScriptsDefer)) {
+    MessageHandler* handler = message_handler();
+    AppendOwnedPreRenderFilter(new WebscaleMakeScriptsDefer(this, handler));
   }
   if (rewrite_options->Enabled(RewriteOptions::kSplitHtml) &&
       server_context()->factory()->UseBeaconResultsInFilters()) {

--- a/net/instaweb/rewriter/rewrite_filter_names.gperf
+++ b/net/instaweb/rewriter/rewrite_filter_names.gperf
@@ -115,6 +115,8 @@ struct FilterMap {
 "strip_image_meta_data",             RewriteOptions::kStripImageMetaData
 "strip_scripts",                     RewriteOptions::kStripScripts
 "trim_urls",                         RewriteOptions::kLeftTrimUrls
+"webscale_make_scripts_async",       RewriteOptions::kWebscaleMakeScriptsAsync
+"webscale_make_scripts_defer",       RewriteOptions::kWebscaleMakeScriptsDefer
 %%
 
 RewriteOptions::Filter RewriteOptions::LookupFilter(

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -19,7 +19,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <set>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "base/logging.h"
 #include "net/instaweb/rewriter/public/domain_lawyer.h"
@@ -63,6 +65,8 @@ const char RewriteOptions::kAllowOptionsToBeSetByCookies[] =
 const char RewriteOptions::kAlwaysMobilize[] = "AlwaysMobilize";
 const char RewriteOptions::kAlwaysRewriteCss[] = "AlwaysRewriteCss";
 const char RewriteOptions::kAnalyticsID[] = "AnalyticsID";
+const char RewriteOptions::kCustomAsyncUrl[] = "CustomAsyncUrl";
+const char RewriteOptions::kCustomDeferUrl[] = "CustomDeferUrl";
 const char RewriteOptions::kAvoidRenamingIntrospectiveJavascript[] =
     "AvoidRenamingIntrospectiveJavascript";
 const char RewriteOptions::kAwaitPcacheLookup[] = "AwaitPcacheLookup";
@@ -905,6 +909,8 @@ const RewriteOptions::FilterEnumToIdAndNameEntry
         {RewriteOptions::kStripImageMetaData, "md", "Strip Image Meta Data"},
         {RewriteOptions::kStripNonCacheable, "nc", "Strip Non Cacheable"},
         {RewriteOptions::kStripScripts, "ss", "Strip Scripts"},
+        {RewriteOptions::kWebscaleMakeScriptsAsync, "wmsa", "Add Async To Scripts"},
+        {RewriteOptions::kWebscaleMakeScriptsDefer, "wmsd", "Add Defer To Scripts"},
 };
 
 const RewriteOptions::Filter kImagePreserveUrlDisabledFilters[] = {
@@ -2510,6 +2516,8 @@ void RewriteOptions::AddProperties() {
 
 RewriteOptions::~RewriteOptions() {
   STLDeleteElements(&custom_fetch_headers_);
+  STLDeleteElements(&custom_async_urls_);
+  STLDeleteElements(&custom_defer_urls_);
   STLDeleteElements(&experiment_specs_);
   STLDeleteElements(&url_cache_invalidation_entries_);
   STLDeleteValues(&rejected_request_map_);
@@ -3352,6 +3360,10 @@ RewriteOptions::ParseAndSetOptionFromNameWithScope(
     RetainComment(arg);
   } else if (StringCaseEqual(name, kBlockingRewriteRefererUrls)) {
       EnableBlockingRewriteForRefererUrlPattern(arg);
+  } else if (StringCaseEqual(name, kCustomAsyncUrl)) {
+    AddCustomAsyncUrl(arg);
+  } else if (StringCaseEqual(name, kCustomDeferUrl)) {
+    AddCustomDeferUrl(arg);
   } else {
     result = RewriteOptions::kOptionNameUnknown;
   }
@@ -3860,6 +3872,16 @@ void RewriteOptions::Merge(const RewriteOptions& src) {
   for (int i = 0, n = src.custom_fetch_headers_.size(); i < n; ++i) {
     NameValue* nv = src.custom_fetch_headers_[i];
     AddCustomFetchHeader(nv->name, nv->value);
+  }
+
+  for (int i = 0, n = src.custom_async_urls_.size(); i < n; ++i) {
+    GoogleString* nv = src.custom_async_urls_[i];
+    AddCustomAsyncUrl(nv->c_str());
+  }
+
+  for (int i = 0, n = src.custom_defer_urls_.size(); i < n; ++i) {
+    GoogleString* nv = src.custom_defer_urls_[i];
+    AddCustomDeferUrl(nv->c_str());
   }
 
   for (int i = 0, n = src.num_url_valued_attributes(); i < n; ++i) {
@@ -4586,6 +4608,16 @@ bool RewriteOptions::MergeOK() const {
 void RewriteOptions::AddCustomFetchHeader(const StringPiece& name,
                                           const StringPiece& value) {
   custom_fetch_headers_.push_back(new NameValue(name, value));
+}
+
+void RewriteOptions::AddCustomAsyncUrl(const StringPiece& value) {
+  Modify();
+  custom_async_urls_.push_back(new GoogleString(value.data(), value.size()));
+}
+
+void RewriteOptions::AddCustomDeferUrl(const StringPiece& value) {
+  Modify();
+  custom_defer_urls_.push_back(new GoogleString(value.data(), value.size()));
 }
 
 // We expect experiment_specs_.size() to be small (not more than 2 or 3)

--- a/net/instaweb/rewriter/webscale_make_scripts_async.cc
+++ b/net/instaweb/rewriter/webscale_make_scripts_async.cc
@@ -79,16 +79,11 @@ GoogleString WebscaleMakeScriptsAsync::ConstructPatternFromCustomUrls(const Rewr
   GoogleString prefix = "";
   GoogleString pattern = "";
 
-  if (number_of_custom_urls == 0) {
-    return pattern;
+  for(int i = 0; i < number_of_custom_urls; i++) {
+    pattern += prefix + RE2::QuoteMeta(options->custom_async_url(i)->c_str());
+    prefix = '|';
   }
-  else {
-    for(int i = 0; i < number_of_custom_urls; i++) {
-      pattern += prefix + RE2::QuoteMeta(options->custom_async_url(i)->c_str());
-      prefix = '|';
-    }
-    return pattern;
-  }
+  return pattern;
 }
 
 

--- a/net/instaweb/rewriter/webscale_make_scripts_async.cc
+++ b/net/instaweb/rewriter/webscale_make_scripts_async.cc
@@ -1,0 +1,108 @@
+/*
+ *  COPYRIGHT:
+ *     (C) Copyright Webscale Networks 2017.
+ *      Licensed Materials - All Rights Reserved.
+ *    
+*/
+
+#include <vector>
+
+#include "base/logging.h"
+#include "net/instaweb/rewriter/public/rewrite_driver.h"
+#include "net/instaweb/rewriter/public/rewrite_driver_factory.h"
+#include "net/instaweb/rewriter/public/webscale_make_scripts_async.h"
+#include "pagespeed/kernel/html/html_element.h"
+#include "pagespeed/kernel/html/html_name.h"
+#include "pagespeed/kernel/html/html_node.h"
+#include "pagespeed/kernel/base/message_handler.h"
+#include "pagespeed/kernel/base/statistics.h"
+#include "pagespeed/kernel/base/string.h"
+#include "pagespeed/kernel/base/string_util.h"
+#include "pagespeed/kernel/util/re2.h"
+
+namespace net_instaweb {
+
+WebscaleMakeScriptsAsync::WebscaleMakeScriptsAsync(RewriteDriver* rewrite_driver, MessageHandler* message_handler)
+    : CommonFilter(rewrite_driver) {
+  Statistics* statistics = rewrite_driver->statistics();
+  message_handler = driver()->message_handler();
+  escaped_urls = ConstructPatternFromCustomUrls(rewrite_driver->options());
+}
+
+WebscaleMakeScriptsAsync::~WebscaleMakeScriptsAsync(){
+}
+
+void WebscaleMakeScriptsAsync::InitStats(Statistics* statistics) {
+}
+
+
+void WebscaleMakeScriptsAsync::StartDocumentImpl() {
+}
+
+
+void WebscaleMakeScriptsAsync::StartElementImpl(HtmlElement* element) {
+  message_handler = driver()->message_handler();
+
+  // Script element found.
+  if (element->keyword() == HtmlName::kScript) {
+    const char* src_attribute = element->EscapedAttributeValue(HtmlName::kSrc);
+    // Script element has a 'src' attribute.
+    if (src_attribute != NULL) {
+      // Convert the src element to a GoogleString format for compatibility.
+      GoogleString* src_string = new GoogleString(src_attribute);
+
+      // If there are no custom urls mentioned, print a message and do nothing.
+      if (escaped_urls == "") {
+        message_handler->Message(
+          kInfo, "No custom urls provided.");
+      }
+      else {
+        // A full match of the custom url needs to be found.
+        bool match = RE2::FullMatch(src_string->c_str(), escaped_urls.c_str());
+        if (match) {
+          // If a match is found, add the async attribute.
+          driver()->AddAttribute(element, HtmlName::kAsync, "true");
+          // Set the debug comment so that it will be displayed when
+          // ModPagespeedEnabledFilters=+debug is used.
+          driver()->InsertDebugComment("Webscale added an async attribute successfully", element);
+          message_handler->Message(
+            kInfo, "Adding an async attribute to %s.", src_string->c_str());
+        } else {
+            message_handler->Message(
+              kInfo, "Not adding an async attribute to %s.", src_string->c_str());
+        }
+      }
+    }
+  }
+}
+
+// Construct a regular expressions with the custom urls provied. Each custom
+// url will be escaped and an OR of all the escaped urls will be constructed
+// for pattern matching.  Pattern matching is preferred here instead of
+// iterating the list of cusotm urls every time a src attribute is encoutered.
+// This make comparison faster.
+GoogleString WebscaleMakeScriptsAsync::ConstructPatternFromCustomUrls(const RewriteOptions* options) {
+  const int number_of_custom_urls = options->num_custom_async_urls();
+  GoogleString pattern = "";
+
+  if (number_of_custom_urls == 0) {
+    return pattern;
+  }
+  else {
+    for(int i = 0; i < number_of_custom_urls - 1; i++) {
+      pattern += RE2::QuoteMeta(options->custom_async_url(i)->c_str());
+      pattern += '|';
+    }
+    pattern += RE2::QuoteMeta(options->custom_async_url(number_of_custom_urls - 1)->c_str());
+    return pattern;
+  }
+}
+
+
+void WebscaleMakeScriptsAsync::EndElementImpl(HtmlElement* element) {
+}
+
+void WebscaleMakeScriptsAsync::EndDocument() {
+}
+
+}

--- a/net/instaweb/rewriter/webscale_make_scripts_defer.cc
+++ b/net/instaweb/rewriter/webscale_make_scripts_defer.cc
@@ -79,16 +79,11 @@ GoogleString WebscaleMakeScriptsDefer::ConstructPatternFromCustomUrls(const Rewr
   GoogleString pattern = "";
   GoogleString prefix = "";
 
-  if (number_of_custom_urls == 0) {
-    return pattern;
+  for(int i = 0; i < number_of_custom_urls; i++) {
+    pattern += prefix + RE2::QuoteMeta(options->custom_defer_url(i)->c_str());
+    prefix = '|';
   }
-  else {
-    for(int i = 0; i < number_of_custom_urls; i++) {
-      pattern += prefix + RE2::QuoteMeta(options->custom_defer_url(i)->c_str());
-      prefix = '|';
-    }
-    return pattern;
-  }
+  return pattern;
 }
 
 

--- a/net/instaweb/rewriter/webscale_make_scripts_defer.cc
+++ b/net/instaweb/rewriter/webscale_make_scripts_defer.cc
@@ -1,0 +1,109 @@
+/*
+ *  COPYRIGHT:
+ *     (C) Copyright Webscale Networks 2017.
+ *      Licensed Materials - All Rights Reserved.
+ *     
+*/
+
+#include <vector>
+
+#include "base/logging.h"
+#include "net/instaweb/rewriter/public/rewrite_driver.h"
+#include "net/instaweb/rewriter/public/rewrite_driver_factory.h"
+#include "net/instaweb/rewriter/public/webscale_make_scripts_defer.h"
+#include "pagespeed/kernel/html/html_element.h"
+#include "pagespeed/kernel/html/html_name.h"
+#include "pagespeed/kernel/html/html_node.h"
+#include "pagespeed/kernel/base/message_handler.h"
+#include "pagespeed/kernel/base/statistics.h"
+#include "pagespeed/kernel/base/string.h"
+#include "pagespeed/kernel/base/string_util.h"
+#include "pagespeed/kernel/util/re2.h"
+
+namespace net_instaweb {
+
+WebscaleMakeScriptsDefer::WebscaleMakeScriptsDefer(RewriteDriver* rewrite_driver, MessageHandler* message_handler)
+    : CommonFilter(rewrite_driver) {
+  Statistics* statistics = rewrite_driver->statistics();
+  message_handler = driver()->message_handler();
+  escaped_urls = ConstructPatternFromCustomUrls(rewrite_driver->options());
+}
+
+WebscaleMakeScriptsDefer::~WebscaleMakeScriptsDefer(){
+}
+
+void WebscaleMakeScriptsDefer::InitStats(Statistics* statistics) {
+}
+
+
+void WebscaleMakeScriptsDefer::StartDocumentImpl() {
+}
+
+
+void WebscaleMakeScriptsDefer::StartElementImpl(HtmlElement* element) {
+  message_handler = driver()->message_handler();
+
+  // Script element found.
+  if (element->keyword() == HtmlName::kScript) {
+    const char* src_attribute = element->EscapedAttributeValue(HtmlName::kSrc);
+    // Script element has a 'src' attribute.
+    if (src_attribute != NULL) {
+      // Convert the src element to a GoogleString format for compatibility.
+      GoogleString* src_string = new GoogleString(src_attribute);
+
+      // If there are no custom urls mentioned, print a message and do nothing.
+      if (escaped_urls == "") {
+        message_handler->Message(
+          kInfo, "No Urls provided.");
+      }
+      else {
+        // A full match of the custom url needs to be found.
+        bool match = RE2::FullMatch(src_string->c_str(), escaped_urls.c_str());
+
+        if (match) {
+          // If a match is found, add the defer attribute.
+          driver()->AddAttribute(element, HtmlName::kDefer, "true");
+          // Set the debug comment so that it will be displayed when
+          // ModPagespeedEnabledFilters=+debug is used.
+          driver()->InsertDebugComment("Webscale added a defer attribute successfully", element);
+          message_handler->Message(
+            kInfo, "Adding a defer attribute to %s.", src_string->c_str());
+        } else {
+            message_handler->Message(
+              kInfo, "Not adding a defer attribute to %s.", src_string->c_str());
+        }
+      }
+    }
+  }
+}
+
+
+// Construct a regular expressions with the custom urls provied. Each custom
+// url will be escaped and an OR of all the escaped urls will be constructed
+// for pattern matching.  Pattern matching is preferred here instead of
+// iterating the list of cusotm urls every time a src attribute is encoutered.
+// This make comparison faster.
+GoogleString WebscaleMakeScriptsDefer::ConstructPatternFromCustomUrls(const RewriteOptions* options) {
+  const int number_of_custom_urls = options->num_custom_defer_urls();
+  GoogleString pattern = "";
+
+  if (number_of_custom_urls == 0) {
+    return pattern;
+  }
+  else {
+    for(int i = 0; i < number_of_custom_urls - 1; i++) {
+      pattern += RE2::QuoteMeta(options->custom_defer_url(i)->c_str());
+      pattern += '|';
+    }
+      pattern += RE2::QuoteMeta(options->custom_defer_url(number_of_custom_urls - 1)->c_str());
+    return pattern;
+  }
+}
+
+
+void WebscaleMakeScriptsDefer::EndElementImpl(HtmlElement* element) {
+}
+
+void WebscaleMakeScriptsDefer::EndDocument() {
+}
+

--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -120,6 +120,8 @@ const char kModPagespeedBlockingRewriteRefererUrls[] =
 const char kModPagespeedConsoleDomains[] = "ModPagespeedConsoleDomains";
 const char kModPagespeedCreateSharedMemoryMetadataCache[] =
     "ModPagespeedCreateSharedMemoryMetadataCache";
+const char kModPagespeedCustomAsyncUrl[] = "ModPagespeedCustomAsyncUrl";
+const char kModPagespeedCustomDeferUrl[] = "ModPagespeedCustomDeferUrl";
 const char kModPagespeedCustomFetchHeader[] = "ModPagespeedCustomFetchHeader";
 const char kModPagespeedDisableFilters[] = "ModPagespeedDisableFilters";
 const char kModPagespeedDisableForBots[] = "ModPagespeedDisableForBots";
@@ -1775,6 +1777,10 @@ static const command_rec mod_pagespeed_filter_cmds[] = {
   APACHE_CONFIG_OPTION(kModPagespeedBlockingRewriteRefererUrls,
                        "wildcard_spec for referer urls which trigger blocking "
                        "rewrites"),
+  APACHE_CONFIG_OPTION(kModPagespeedCustomAsyncUrl,
+        "List of urls to be made async."),
+  APACHE_CONFIG_OPTION(kModPagespeedCustomDeferUrl,
+        "List of urls to be deferred."),
 
   // All two parameter options that are allowed in <Directory> blocks.
   APACHE_CONFIG_DIR_OPTION2(kModPagespeedCustomFetchHeader,

--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -1726,6 +1726,10 @@ static const command_rec mod_pagespeed_filter_cmds[] = {
   APACHE_CONFIG_DIR_OPTION(kModPagespeedSpeedTracking,
         "Increase the percentage of sites that have Google Analytics page "
         "speed tracking"),
+  APACHE_CONFIG_DIR_OPTION(kModPagespeedCustomAsyncUrl,
+        "List of urls to be made async."),
+  APACHE_CONFIG_DIR_OPTION(kModPagespeedCustomDeferUrl,
+        "List of urls to be deferred."),
 
   // All one parameter deprecated options.
   APACHE_CONFIG_DIR_OPTION(kModPagespeedImgInlineMaxBytes,
@@ -1777,10 +1781,6 @@ static const command_rec mod_pagespeed_filter_cmds[] = {
   APACHE_CONFIG_OPTION(kModPagespeedBlockingRewriteRefererUrls,
                        "wildcard_spec for referer urls which trigger blocking "
                        "rewrites"),
-  APACHE_CONFIG_OPTION(kModPagespeedCustomAsyncUrl,
-        "List of urls to be made async."),
-  APACHE_CONFIG_OPTION(kModPagespeedCustomDeferUrl,
-        "List of urls to be deferred."),
 
   // All two parameter options that are allowed in <Directory> blocks.
   APACHE_CONFIG_DIR_OPTION2(kModPagespeedCustomFetchHeader,


### PR DESCRIPTION
New pagespeed filters enables custom urls to be async-ed or deferred. The custom urls for this functionality should be provided in the vhost configuration.

https://github.com/webscale-networks/control/issues/2678

**Example:**
    ModPagespeedCustomDeferUrl "rabbits.js"
    ModPagespeedCustomAsyncUrl "rabbits2.js"
    ModPagespeedEnableFilters webscale_make_scripts_async
    ModPagespeedEnableFilters webscale_make_scripts_defer

**References:** 
Wiki for pagespeed build -https://sites.google.com/a/lagrangesystems.com/home/engineering/pagespeed-development