### PR TITLE
Restore full image optimization instructions in optimized URLs.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+/**
+ * Jenkinsfile existing in a project is seen by jenkins and used to build a
+ * project. For documentation, see:
+ * https://jenkins.io/doc/book/pipeline/jenkinsfile/. For variables that can
+ * be used, see
+ * https://jenkins.webscalenetworks.com/job/product/job/control/pipeline-syntax/globals.
+ */
+
+node {
+  /* Checks out the main source tree */
+  stage('scm') {
+    /* Delete the entire directory first. */
+    deleteDir()
+    dir('mod_pagespeed/src') {
+      checkout(scm)
+    }
+  }
+
+  stage('build') {
+    sh('mod_pagespeed/src/build.sh')
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ -z "$WORKSPACE" ]; then
+  WORKSPACE=$PWD
+fi
+if ! test -f "$WORKSPACE/mod_pagespeed/src/build.sh" -a -f "$WORKSPACE/mod_pagespeed/src/install/Makefile"; then
+  printf "Something is wrong with the workspace\n" >&2
+  exit 1
+fi
+    
+# BRANCH_NAME is set by jenkins to the name of the branch or tag being built.
+if [ -z "$BRANCH_NAME" ]; then
+  printf "BRANCH_NAME must be set\n" >&2
+  exit 1
+fi
+
+
+SPEC=$(basename $BRANCH_NAME)
+echo "Building from $BRANCH_NAME"
+
+SVN_OUT="svn+ssh://svn.webscalenetworks.com/repo/pagespeed/$SPEC"
+if [ "${BRANCH_NAME/tags\//}" != "${BRANCH_NAME}" ]; then
+  # Build for release when tagged
+  BUILDTYPE=Release
+  if svn info "$SVN_OUT" >/dev/null 2>&1; then
+    printf "Pagespeed %s already built. Tag another version.\n" "$SPEC" >&2
+    exit 1
+  fi
+else
+  BUILDTYPE=Debug
+fi
+
+WORKSPACE=$PWD
+
+if [ ! -d depot_tools ]; then
+  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  cd depot_tools
+  git checkout --quiet --force c20f470011e2ea4d81527976f3bded2c13e258af
+  cd ..
+fi
+export DEPOT_TOOLS_UPDATE=0
+export PATH=$PWD/depot_tools:$PATH
+
+cd mod_pagespeed
+gclient config https://github.com/webscale-networks/mod_pagespeed.git --unmanaged --name=src
+gclient sync --force --jobs=1
+
+cd src
+cat <<EOF >rebuild
+make --jobs=4 \
+  AR.host=$PWD/build/wrappers/ar.sh \
+  AR.target=$PWD/build/wrappers/ar.sh \
+  BUILDTYPE=$BUILDTYPE \
+  all \
+  mod_pagespeed_test \
+  pagespeed_automatic_test
+out/$BUILDTYPE/mod_pagespeed_test || true
+out/$BUILDTYPE/pagespeed_automatic_test || true
+EOF
+chmod +x rebuild
+./rebuild
+
+cd $WORKSPACE
+
+export DESTDIR=$WORKSPACE/pagespeed
+rm -rf "$DESTDIR"
+
+export APACHE_ROOT=$DESTDIR/usr/local/httpd-lg
+export APACHE_MODULES=$APACHE_ROOT/modules
+export APACHE_CONTROL_PROGRAM=$APACHE_ROOT/modules
+export APACHE_DOC_ROOT=$(mktemp -d)
+export APACHE_USER=$(id -un)
+export APACHE_CONF_D=$APACHE_ROOT/conf
+export BINDIR=$DESTDIR/usr/local/bin
+export STAGING_DIR=$WORKSPACE/mod_pagespeed.install
+export MOD_PAGESPEED_CACHE=$DESTDIR/var/cache/mod_pagespeed
+export MOD_PAGESPEED_LOG=$DESTDIR/var/log/pagespeed
+
+mkdir -p "$APACHE_MODULES" "$APACHE_CONF_D" "$BINDIR"
+
+# The debug config is included by default, but contains a bunch of stuff we do not want
+# The makefile defaults to using the Release build, but we may want to override this
+sed -e 's/debug.conf.template *$//' -e "s/Release/$BUILDTYPE/g" \
+  <mod_pagespeed/src/install/Makefile \
+  >mod_pagespeed/src/install/Makefile.lagrange
+BUILDTYPE=$BUILDTYPE \
+make -C mod_pagespeed/src/install \
+  -e \
+  -f Makefile.lagrange \
+  staging install
+
+# No need to keep the Apache 2.2 version
+rm pagespeed/usr/local/httpd-lg/modules/mod_pagespeed.so
+
+sed -i -e "s@$DESTDIR@@g" $DESTDIR/usr/local/httpd-lg/conf/pagespeed.conf
+
+rm -rf "$APACHE_DOC_ROOT"
+
+if [ -z "$PAGESPEED_VERSION" ]; then
+  PAGESPEED_VERSION=$(grep '#define MOD_PAGESPEED_VERSION_STRING' \
+    mod_pagespeed/src/out/$BUILDTYPE/obj/gen/net/instaweb/public/version.h |
+    awk '{print $3}' | tr -d '"')
+fi
+printf "pagespeed version is %s\n" "$PAGESPEED_VERSION"
+
+if [ -z "$SPEC" ]; then
+  exit 0
+fi
+
+cd "$DESTDIR"
+if svn info "$SVN_OUT" >/dev/null 2>&1; then
+  svn delete "$SVN_OUT" -m "Delete for replacement with $PAGESPEED_VERSION"
+fi
+svn import --no-ignore --quiet . $SVN_OUT -m "Update pagespeed/$SPEC to version $PAGESPEED_VERSION"

--- a/net/instaweb/rewriter/image_url_encoder.cc
+++ b/net/instaweb/rewriter/image_url_encoder.cc
@@ -115,15 +115,23 @@ void ImageUrlEncoder::Encode(const StringVector& urls,
       }
     }
 
-    if (data->may_use_small_screen_quality()) {
-      rewritten_url->push_back(kCodeSmallScreen);
-    }
-    if (data->may_use_save_data_quality()) {
-      rewritten_url->push_back(kCodeSaveData);
-    }
+    // Migration steps:
+    //   Existing servers know how to decode everything but the following two
+    //   symbols: small-screen and save-data.  So commit the full decoding code
+    //   first, then upgrade all existing servers, then restore the following
+    //   encoding steps, then upgrade all servers again.
+
+    // if (data->may_use_small_screen_quality()) {
+    //   rewritten_url->push_back(kCodeSmallScreen);
+    // }
+    // if (data->may_use_save_data_quality()) {
+    //   rewritten_url->push_back(kCodeSaveData);
+    // }
+
     if (data->mobile_user_agent()) {
       rewritten_url->push_back(kCodeMobileUserAgent);
     }
+
     switch (data->libwebp_level()) {
       case ResourceContext::LIBWEBP_LOSSY_ONLY:
         rewritten_url->push_back(kCodeWebpLossy);


### PR DESCRIPTION
A very old previous commit (9741fa186) removed some of the optimization
configuration in the URL of optimized images. There was no explanation
given for this, and this has been linked to the cause of incorrect
optimization when processing a cache-miss through a CDN. This change
restores the previous url configuration as well as adds configuration for
the newer options such as small-screen and save-data.