### PR TITLE
Fix #5 defer filter leaves async

### DIFF
--- a/net/instaweb/rewriter/webscale_make_scripts_async.cc
+++ b/net/instaweb/rewriter/webscale_make_scripts_async.cc
@@ -57,6 +57,7 @@ void WebscaleMakeScriptsAsync::StartElementImpl(HtmlElement* element) {
         if (match) {
           // If a match is found, add the async attribute.
           driver()->AddAttribute(element, HtmlName::kAsync, "true");
+          element->DeleteAttribute(HtmlName::kDefer);
           // Set the debug comment so that it will be displayed when
           // ModPagespeedFilters=+debug is used.
           driver()->InsertDebugComment("Webscale added an async attribute successfully", element);

--- a/net/instaweb/rewriter/webscale_make_scripts_defer.cc
+++ b/net/instaweb/rewriter/webscale_make_scripts_defer.cc
@@ -57,6 +57,7 @@ void WebscaleMakeScriptsDefer::StartElementImpl(HtmlElement* element) {
         if (match) {
           // If a match is found, add the defer attribute.
           driver()->AddAttribute(element, HtmlName::kDefer, "true");
+          element->DeleteAttribute(HtmlName::kAsync);
           // Set the debug comment so that it will be displayed when
           // ModPagespeedFilters=+debug is used.
           driver()->InsertDebugComment("Webscale added a defer attribute successfully", element);


### PR DESCRIPTION
If a defer filter is specified to add the defer attribute to a script element,
it must also remove an async attribute, otherwise, the browser may give
priority to async. This change does that. It also removes the defer attribute
from elements where the async attribute is added.