### PR TITLE
Fix #9 X-Mod-Pagespeed header ends with "null"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,8 +54,8 @@ cd mod_pagespeed
 gclient config https://github.com/webscale-networks/mod_pagespeed.git --unmanaged --name=src
 gclient sync --force --jobs=1
 
-if [ -n "$REVISION" ]; then
-  sed -i.orig -Ee "s/LASTCHANGE=[^ ]+/LASTCHANGE=$REVISION/" src/build/lastchange.sh
+if [ -n "$LASTCHANGE" ]; then
+  sed -i.orig -Ee "s/LASTCHANGE=[^ ]+/LASTCHANGE=$LASTCHANGE/" src/build/lastchange.sh
 fi
 
 cd src


### PR DESCRIPTION
The X-Mod-Pagespeed header is populated partially via LASTCHANGE from src/build/lastchange.sh in the pagespeed build process. This script looks like they intended for local builders to modify it, but it is always fixed at zero. This fixes the earlier, failed attempt to put our own version number in that field.