### PR TITLE
Close #16, set request id in request context

### DIFF
--- a/pagespeed/apache/instaweb_handler.cc
+++ b/pagespeed/apache/instaweb_handler.cc
@@ -117,6 +117,16 @@ InstawebHandler::InstawebHandler(request_rec* request)
   // Note: request_context_ must be initialized before ComputeCustomOptions().
   ComputeCustomOptions();
   request_context_->set_options(options_->ComputeHttpOptions());
+
+  // If there is a request ID present in the request notes, set it here
+  // in the request context.
+  const char* request_id = apr_table_get(request->notes, "REQUEST_ID");
+  if (request_id) {
+    ap_log_rerror(APLOG_MARK, APLOG_DEBUG, APR_SUCCESS, request,
+      "Request ID value from request context: %s", request_id);
+    int64 req_id = strtoll(request_id, NULL, 10);
+    request_context_->set_request_id(req_id);
+  }
 }
 
 InstawebHandler::~InstawebHandler() {


### PR DESCRIPTION
This PR is to set the request ID in Pagespeed request context if one has been set in
the request notes during upstream processing in Apache. When it is present, the pagespeed
beacon includes the request ID as a query param in the GET request and allows us to
annotate individual requests with their corresponding page load times.

Verification: this can be verified by installing the control branch 5685 on a proxy and initiating a full page load of the application. Inspecting the logs will show the original GET request for the page load and then a subsequent GET request for pagespeed beacon with a canned request ID of `987654321`. Once issue 5685 is complete, this value will be a 64-bit integer that is a unique request ID.

Close #16 